### PR TITLE
Changes required to compile on emscripten target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,11 @@ print_config()
 
 add_subdirectory(libdevcore)
 add_subdirectory(libdevcrypto)
-add_subdirectory(libp2p)
+if (NOT EMSCRIPTEN)
+	add_subdirectory(libp2p)
 
-if (TOOLS)
-	add_subdirectory(rlp)
+	if (TOOLS)
+		add_subdirectory(rlp)
+	endif()
 endif()
 

--- a/libdevcore/TrieDB.cpp
+++ b/libdevcore/TrieDB.cpp
@@ -18,6 +18,7 @@
  * @author Gav Wood <i@gavwood.com>
  * @date 2014
  */
+#if !defined(ETH_EMSCRIPTEN)
 
 #include "Common.h"
 #include "TrieDB.h"
@@ -28,3 +29,5 @@ h256 const dev::c_shaNull = sha3(rlp(""));
 h256 const dev::EmptyTrie = sha3(rlp(""));
 
 const char* TrieDBChannel::name() { return "-T-"; }
+
+#endif // ETH_EMSCRIPTEN

--- a/libdevcore/TrieHash.cpp
+++ b/libdevcore/TrieHash.cpp
@@ -19,6 +19,8 @@
  * @date 2014
  */
 
+#if !defined(ETH_EMSCRIPTEN)
+
 #include "TrieHash.h"
 #include "TrieCommon.h"
 #include "TrieDB.h"	// @TODO replace ASAP!
@@ -193,3 +195,5 @@ h256 orderedTrieRoot(std::vector<bytesConstRef> const& _data)
 }
 
 }
+
+#endif // ETH_EMSCRIPTEN

--- a/libdevcore/debugbreak.h
+++ b/libdevcore/debugbreak.h
@@ -101,7 +101,11 @@ __attribute__((gnu_inline, always_inline))
 static void __inline__ debug_break(void)
 {
 	if (HAVE_TRAP_INSTRUCTION) {
+#if defined(ETH_EMSCRIPTEN)
+		asm("debugger");
+#else
 		trap_instruction();
+#endif
 	} else if (DEBUG_BREAK_PREFER_BUILTIN_TRAP_TO_SIGTRAP) {
 		 /* raises SIGILL on Linux x86{,-64}, to continue in gdb:
 		  * (gdb) handle SIGILL stop nopass

--- a/libdevcrypto/CMakeLists.txt
+++ b/libdevcrypto/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
 eth_use(${EXECUTABLE} REQUIRED Dev::devcore Utils::scrypt Cryptopp)
 
-if (NOT DEFINED MSVC)
+if ((NOT EMSCRIPTEN) AND (NOT DEFINED MSVC))
 	eth_use(${EXECUTABLE} REQUIRED Utils::secp256k1)
 endif ()
 

--- a/libdevcrypto/OverlayDB.cpp
+++ b/libdevcrypto/OverlayDB.cpp
@@ -18,6 +18,7 @@
  * @author Gav Wood <i@gavwood.com>
  * @date 2014
  */
+#if !defined(ETH_EMSCRIPTEN)
 
 #include <thread>
 #include <libdevcore/db.h>
@@ -155,3 +156,5 @@ void OverlayDB::kill(h256 const& _h)
 }
 
 }
+
+#endif // ETH_EMSCRIPTEN


### PR DESCRIPTION
This change parametrically excludes some subdirectories from cmake and strips down dependencies so that solidity can be compiled for the emscripten javascript target.
