### PR TITLE
Add support building miniupnpc API version >= 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(EthDependencies)
 include(EthUtils)
 
 include(EthOptions)
-configure_project(PARANOID TOOLS TESTS)
+configure_project(PARANOID TOOLS TESTS MINIUPNPC)
 
 add_subdirectory(libdevcore)
 add_subdirectory(libdevcrypto)

--- a/libp2p/UPnP.cpp
+++ b/libp2p/UPnP.cpp
@@ -17,7 +17,8 @@
 /** @file UPnP.cpp
  * @authors:
  *   Gav Wood <i@gavwood.com>
- * @date 2014
+ *   Lefteris Karapetsas <lefteris@refu.co>
+ * @date 2014, 2015
  */
 
 #include "UPnP.h"
@@ -52,7 +53,11 @@ UPnP::UPnP()
 	int upnperror = 0;
 	memset(m_urls.get(), 0, sizeof(struct UPNPUrls));
 	memset(m_data.get(), 0, sizeof(struct IGDdatas));
+#if MINIUPNPC_API_VERSION >= 14
+	devlist = upnpDiscover(2000, NULL/*multicast interface*/, NULL/*minissdpd socket path*/, 0/*sameport*/, 0/*ipv6*/, 2/*ttl*/, &upnperror);
+#else
 	devlist = upnpDiscover(2000, NULL/*multicast interface*/, NULL/*minissdpd socket path*/, 0/*sameport*/, 0/*ipv6*/, &upnperror);
+#endif
 	if (devlist)
 	{
 		dev = devlist;


### PR DESCRIPTION
As per [miniupnpc changelog](https://github.com/miniupnp/miniupnp/blob/master/miniupnpc/apiversions.txt)
from API version 14 and on a new ttl argument is added to
`upnpDiscover()`.

This PR will allow building with miniupnpc in ArchLinux and
newer versions of Ubuntu which use this API.

For reference I am putting the declaration of `upnpDiscover()` appearing in my machine's version of the library.

``` c++
/* upnpDiscover()
 * discover UPnP devices on the network.
 * The discovered devices are returned as a chained list.
 * It is up to the caller to free the list with freeUPNPDevlist().
 * delay (in millisecond) is the maximum time for waiting any device
 * response.
 * If available, device list will be obtained from MiniSSDPd.
 * Default path for minissdpd socket will be used if minissdpdsock argument
 * is NULL.
 * If multicastif is not NULL, it will be used instead of the default
 * multicast interface for sending SSDP discover packets.
 * If sameport is not null, SSDP packets will be sent from the source port
 * 1900 (same as destination port) otherwise system assign a source port.
 * "searchalltypes" parameter is useful when searching several types,
 * if 0, the discovery will stop with the first type returning results.
 * TTL should default to 2. */
MINIUPNP_LIBSPEC struct UPNPDev *
upnpDiscover(int delay, const char * multicastif,
             const char * minissdpdsock, int sameport,
             int ipv6, unsigned char ttl,
             int * error);
```
