### PR TITLE
Fix compiling for hot_gav libweb3core

### DIFF
--- a/test/libp2p/rlpx.cpp
+++ b/test/libp2p/rlpx.cpp
@@ -37,9 +37,14 @@ using namespace dev::crypto;
 using namespace dev::p2p;
 using namespace CryptoPP;
 
-BOOST_AUTO_TEST_SUITE(rlpx)
+struct RLPXTestFixture {
+	RLPXTestFixture() : s_secp256k1(Secp256k1PP::get()) {}
+	~RLPXTestFixture() {}
 
-static Secp256k1PP s_secp256k1;
+	Secp256k1PP* s_secp256k1;
+};
+BOOST_FIXTURE_TEST_SUITE(rlpx, RLPXTestFixture)
+
 static CryptoPP::AutoSeededRandomPool s_rng;
 static CryptoPP::OID s_curveOID(CryptoPP::ASN1::secp256k1());
 static CryptoPP::DL_GroupParameters_EC<CryptoPP::ECP> s_params(s_curveOID);
@@ -75,7 +80,7 @@ BOOST_AUTO_TEST_CASE(test_secrets_cpp_vectors)
 	
 	// shared-secret = sha3(ecdhe-shared-secret || sha3(nonce || initiator-nonce))
 	Secret ephemeralShared;
-	s_secp256k1.agree(initR.sec(), recvR.pub(), ephemeralShared);
+	s_secp256k1->agree(initR.sec(), recvR.pub(), ephemeralShared);
 	Secret expected(fromHex("20d82c1092f351dc217bd66fa183e801234af14ead40423b6ee25112201c6e5a"));
 	BOOST_REQUIRE(expected == ephemeralShared);
 	
@@ -197,9 +202,9 @@ BOOST_AUTO_TEST_CASE(test_secrets_from_go)
 	bytes ackPlainExpected(fromHex("0x802b052f8b066640bba94a4fc39d63815c377fced6fcb84d27f791c9921ddf3e9bf0108e298f490812847109cbd778fae393e80323fd643209841a3b7f110397f37ec61d84cea03dcc5e8385db93248584e8af4b4d1c832d8c7453c0089687a700"));
 	
 	bytes authPlain = authCipher;
-	BOOST_REQUIRE(s_secp256k1.decryptECIES(recv.sec(), authPlain));
+	BOOST_REQUIRE(s_secp256k1->decryptECIES(recv.sec(), authPlain));
 	bytes ackPlain = ackCipher;
-	BOOST_REQUIRE(s_secp256k1.decryptECIES(init.sec(), ackPlain));
+	BOOST_REQUIRE(s_secp256k1->decryptECIES(init.sec(), ackPlain));
 	
 	CryptoPP::CTR_Mode<CryptoPP::AES>::Encryption m_frameEnc;
 	CryptoPP::CTR_Mode<CryptoPP::AES>::Encryption m_frameDec;
@@ -218,7 +223,7 @@ BOOST_AUTO_TEST_CASE(test_secrets_from_go)
 	
 	// shared-secret = sha3(ecdhe-shared-secret || sha3(nonce || initiator-nonce))
 	Secret ephemeralShared;
-	s_secp256k1.agree(initR.sec(), recvR.pub(), ephemeralShared);
+	s_secp256k1->agree(initR.sec(), recvR.pub(), ephemeralShared);
 	Secret expected(fromHex("0xe3f407f83fc012470c26a93fdff534100f2c6f736439ce0ca90e9914f7d1c381"));
 	BOOST_REQUIRE(expected == ephemeralShared);
 	
@@ -405,27 +410,27 @@ BOOST_AUTO_TEST_CASE(ecies_interop_test_primitives)
 	Secret input1(fromHex("0x0de72f1223915fa8b8bf45dffef67aef8d89792d116eb61c9a1eb02c422a4663"));
 	bytes expect1(fromHex("0x1d0c446f9899a3426f2b89a8cb75c14b"));
 	bytes test1;
-	test1 = s_secp256k1.eciesKDF(input1, bytes(), 16);
+	test1 = s_secp256k1->eciesKDF(input1, bytes(), 16);
 	BOOST_REQUIRE(test1 == expect1);
 	
 	Secret kdfInput2(fromHex("0x961c065873443014e0371f1ed656c586c6730bf927415757f389d92acf8268df"));
 	bytes kdfExpect2(fromHex("0x4050c52e6d9c08755e5a818ac66fabe478b825b1836fd5efc4d44e40d04dabcc"));
 	bytes kdfTest2;
-	kdfTest2 = s_secp256k1.eciesKDF(kdfInput2, bytes(), 32);
+	kdfTest2 = s_secp256k1->eciesKDF(kdfInput2, bytes(), 32);
 	BOOST_REQUIRE(kdfTest2 == kdfExpect2);
 	
 	KeyPair k(Secret(fromHex("0x332143e9629eedff7d142d741f896258f5a1bfab54dab2121d3ec5000093d74b")));
 	Public p(fromHex("0xf0d2b97981bd0d415a843b5dfe8ab77a30300daab3658c578f2340308a2da1a07f0821367332598b6aa4e180a41e92f4ebbae3518da847f0b1c0bbfe20bcf4e1"));
 	Secret agreeExpected(fromHex("0xee1418607c2fcfb57fda40380e885a707f49000a5dda056d828b7d9bd1f29a08"));
 	Secret agreeTest;
-	s_secp256k1.agree(k.sec(), p, agreeTest);
+	s_secp256k1->agree(k.sec(), p, agreeTest);
 	BOOST_REQUIRE(agreeExpected == agreeTest);
 	
 	KeyPair kmK(Secret(fromHex("0x57baf2c62005ddec64c357d96183ebc90bf9100583280e848aa31d683cad73cb")));
 	bytes kmCipher(fromHex("0x04ff2c874d0a47917c84eea0b2a4141ca95233720b5c70f81a8415bae1dc7b746b61df7558811c1d6054333907333ef9bb0cc2fbf8b34abb9730d14e0140f4553f4b15d705120af46cf653a1dc5b95b312cf8444714f95a4f7a0425b67fc064d18f4d0a528761565ca02d97faffdac23de10"));
 	bytes kmPlain = kmCipher;
 	bytes kmExpected(asBytes("a"));
-	BOOST_REQUIRE(s_secp256k1.decryptECIES(kmK.sec(), kmPlain));
+	BOOST_REQUIRE(s_secp256k1->decryptECIES(kmK.sec(), kmPlain));
 	BOOST_REQUIRE(kmExpected == kmPlain);
 	
 	KeyPair kenc(Secret(fromHex("0x472413e97f1fd58d84e28a559479e6b6902d2e8a0cee672ef38a3a35d263886b")));
@@ -435,19 +440,19 @@ BOOST_AUTO_TEST_CASE(ecies_interop_test_primitives)
 	bytes cipher1(fromHex("0x046f647e1bd8a5cd1446d31513bac233e18bdc28ec0e59d46de453137a72599533f1e97c98154343420d5f16e171e5107999a7c7f1a6e26f57bcb0d2280655d08fb148d36f1d4b28642d3bb4a136f0e33e3dd2e3cffe4b45a03fb7c5b5ea5e65617250fdc89e1a315563c20504b9d3a72555"));
 	bytes plainTest1 = cipher1;
 	bytes expectedPlain1 = asBytes("a");
-	BOOST_REQUIRE(s_secp256k1.decryptECIES(kenc.sec(), plainTest1));
+	BOOST_REQUIRE(s_secp256k1->decryptECIES(kenc.sec(), plainTest1));
 	BOOST_REQUIRE(plainTest1 == expectedPlain1);
 	
 	bytes cipher2(fromHex("0x0443c24d6ccef3ad095140760bb143078b3880557a06392f17c5e368502d79532bc18903d59ced4bbe858e870610ab0d5f8b7963dd5c9c4cf81128d10efd7c7aa80091563c273e996578403694673581829e25a865191bdc9954db14285b56eb0043b6288172e0d003c10f42fe413222e273d1d4340c38a2d8344d7aadcbc846ee"));
 	bytes plainTest2 = cipher2;
 	bytes expectedPlain2 = asBytes("aaaaaaaaaaaaaaaa");
-	BOOST_REQUIRE(s_secp256k1.decryptECIES(kenc.sec(), plainTest2));
+	BOOST_REQUIRE(s_secp256k1->decryptECIES(kenc.sec(), plainTest2));
 	BOOST_REQUIRE(plainTest2 == expectedPlain2);
 	
 	bytes cipher3(fromHex("0x04c4e40c86bb5324e017e598c6d48c19362ae527af8ab21b077284a4656c8735e62d73fb3d740acefbec30ca4c024739a1fcdff69ecaf03301eebf156eb5f17cca6f9d7a7e214a1f3f6e34d1ee0ec00ce0ef7d2b242fbfec0f276e17941f9f1bfbe26de10a15a6fac3cda039904ddd1d7e06e7b96b4878f61860e47f0b84c8ceb64f6a900ff23844f4359ae49b44154980a626d3c73226c19e"));
 	bytes plainTest3 = cipher3;
 	bytes expectedPlain3 = asBytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-	BOOST_REQUIRE(s_secp256k1.decryptECIES(kenc.sec(), plainTest3));
+	BOOST_REQUIRE(s_secp256k1->decryptECIES(kenc.sec(), plainTest3));
 	BOOST_REQUIRE(plainTest3 == expectedPlain3);
 }
 

--- a/test/libp2p/rlpx.cpp
+++ b/test/libp2p/rlpx.cpp
@@ -803,7 +803,7 @@ bytes generatePseudorandomPacket(h256 const& _h)
 		ret += _h.asBytes();
 
 	ret.resize(msgSize);
-	return move(ret);
+	return ret;
 }
 
 BOOST_AUTO_TEST_CASE(pseudorandom)


### PR DESCRIPTION
class Secp256k1PP constructor's is private and looks like a
singleton. Should not have a global static object in the tests. Instead
we now have test fixtures which use the ::get() method of the singleton.

DONTBUILD
