### PR TITLE
Patch for crypto++ 5.6.2-4 in ArchLinux

### DIFF
--- a/libdevcrypto/CMakeLists.txt
+++ b/libdevcrypto/CMakeLists.txt
@@ -4,7 +4,7 @@ set(EXECUTABLE devcrypto)
 
 file(GLOB HEADERS "*.h")
 add_library(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
-
+add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
 eth_use(${EXECUTABLE} REQUIRED Dev::devcore Utils::scrypt Cryptopp)
 
 if (NOT EMSCRIPTEN)


### PR DESCRIPTION
As described in https://github.com/ethereum/libethereum/issues/141 this
is an incompatibility introduced by the latest package in ArchLinux. If
using gcc this patch will fix the issue and compile will continue
smoothly.

It may break compilation for other platforms and as such please test
before merging. If it does we need to add some platform detection code
in the cmake file.
