### PR TITLE
Commented out parameter name for copy-constructor for secure_vector

### DIFF
--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -82,7 +82,7 @@ class secure_vector
 {
 public:
 	secure_vector() {}
-	secure_vector(secure_vector<T> const& _c) = default;
+	secure_vector(secure_vector<T> const& /*_c*/) = default;  // See https://github.com/ethereum/libweb3core/pull/44
 	explicit secure_vector(unsigned _size): m_data(_size) {}
 	explicit secure_vector(unsigned _size, T _item): m_data(_size, _item) {}
 	explicit secure_vector(std::vector<T> const& _c): m_data(_c) {}


### PR DESCRIPTION
Commented out parameter name for copy-constructor for secure_vector<> class to work around GCC bug which is marked as fixed in GCC-4.9.0.   The compiler issues a warning about the named parameter not being used within synthesized code.   The warning is obviously not very useful.   The parameter _is_ used, but the name is not used, because the code is synthesized.

This is a workaround for the warning, which breaks the build on certain systems because warnings-as-errors is enabled.

http://stackoverflow.com/questions/12793412/defaulted-copy-constructor-and-copy-assignment-assignment-operator-giving-strang

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57211
