### PR TITLE
Fix node discovery: Boot nodes should be unknown

### DIFF
--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -536,7 +536,7 @@ void Host::requirePeer(NodeID const& _n, NodeIPEndpoint const& _endpoint)
 			}
 		// required for discovery
 		if (m_nodeTable)
-			m_nodeTable->addNode(*p, NodeTable::NodeRelation::Known);
+			m_nodeTable->addNode(*p, NodeTable::NodeRelation::Unknown);
 	}
 	else if (m_nodeTable)
 	{


### PR DESCRIPTION
to trigger the ping-pong-dance.
