### PR TITLE
Disable Boost auto-linking

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,5 +21,22 @@ file(GLOB HEADERS "*.h")
 add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 eth_use(${EXECUTABLE} REQUIRED Dev::devcrypto Dev::devcore Dev::p2p)
 
+# Disable Boost auto-linking, where boost libraries are automatically
+# added to the link step for platforms which support that feature, which
+# in our case appears only to be for Windows.   Presumably this is
+# implemented using #pragma comment(lib ...)
+#
+# See https://support.microsoft.com/en-us/kb/153901.
+#
+# We don't want this automatic behavior, because it can add libraries
+# to the link step which we don't actually need or want, depending on
+# how cleanly #include dependencies have been managed, sometimes within
+# header files which we don't even author.  It is much better for us
+# just to manage these dependencies explicitly ourselves.
+#
+# See http://www.boost.org/doc/libs/1_40_0/more/getting_started/windows.html#auto-linking
+#
+add_definitions(-DBOOST_ALL_NO_LIB)
+
 target_link_libraries(${EXECUTABLE} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES})
 target_link_libraries(${EXECUTABLE} ${Boost_REGEX_LIBRARIES})


### PR DESCRIPTION
Disable Boost auto-linking, where boost libraries are automatically added to the link step for platforms which support that feature, which in our case appears only to be for Windows.   Presumably this is implemented using #pragma comment(lib ...)

See https://support.microsoft.com/en-us/kb/153901.

We don't want this automatic behavior, because it can add libraries to the link step which we don't actually need or want, depending on how cleanly #include dependencies have been managed, sometimes within header files which we don't even author.  It is much better for us just to manage these dependencies explicitly ourselves.

See http://www.boost.org/doc/libs/1_40_0/more/getting_started/windows.html#auto-linking
