### PR TITLE
Fix JS data decoder to always decode hex even if not 0x prefixed.

### DIFF
--- a/libdevcore/CommonJS.cpp
+++ b/libdevcore/CommonJS.cpp
@@ -30,18 +30,18 @@ namespace dev
 
 bytes jsToBytes(string const& _s, OnFailed _f)
 {
-	if (_s.substr(0, 2) == "0x")
-		// Hex
-		return fromHex(_s.substr(2));
-	else if (_s.find_first_not_of("0123456789") == string::npos)
-		// Decimal
-		return toCompactBigEndian(bigint(_s));
-	else if (_f == OnFailed::Empty)
-		return bytes();
-	else if (_f == OnFailed::InterpretRaw)
-		return asBytes(_s);
-	else
-		throw invalid_argument("Cannot intepret '" + _s + "' as bytes; must be 0x-prefixed hex or decimal.");
+	try
+	{
+		return fromHex(_s, WhenError::Throw);
+	}
+	catch (...)
+	{
+		if (_f == OnFailed::InterpretRaw)
+			return asBytes(_s);
+		else if (_f == OnFailed::Throw)
+			throw invalid_argument("Cannot intepret '" + _s + "' as bytes; must be 0x-prefixed hex or decimal.");
+	}
+	return bytes();
 }
 
 bytes padded(bytes _b, unsigned _l)

--- a/libdevcore/CommonJS.h
+++ b/libdevcore/CommonJS.h
@@ -67,7 +67,8 @@ template<typename T> std::string toJS(T const& _i)
 
 enum class OnFailed { InterpretRaw, Empty, Throw };
 
-/// Convert string to byte array. Input parameters can be hex or dec. Returns empty array if invalid input e.g neither dec or hex.
+/// Convert string to byte array. Input parameter is hex, optionally prefixed by "0x".
+/// Returns empty array if invalid input.
 bytes jsToBytes(std::string const& _s, OnFailed _f = OnFailed::Empty);
 /// Add '0' on, or remove items from, the front of @a _b until it is of length @a _l.
 bytes padded(bytes _b, unsigned _l);

--- a/test/libdevcore/CommonJS.cpp
+++ b/test/libdevcore/CommonJS.cpp
@@ -45,11 +45,11 @@ BOOST_AUTO_TEST_CASE(test_toJS)
 BOOST_AUTO_TEST_CASE(test_jsToBytes)
 {
 	bytes a = {0xff, 0xaa, 0xbb, 0xcc};
-	bytes b = {0x9, 0x13, 0xff, 0xc2, 0x83};
+	bytes b = {0x03, 0x89, 0x90, 0x23, 0x42, 0x43};
 	BOOST_CHECK(a == jsToBytes("0xffaabbcc"));
 	BOOST_CHECK(b == jsToBytes("38990234243"));
 	BOOST_CHECK(bytes() == jsToBytes(""));
-	BOOST_CHECK(bytes() == jsToBytes("Neither decimal nor hexadecimal"));
+	BOOST_CHECK(bytes() == jsToBytes("Invalid hex chars"));
 }
 
 BOOST_AUTO_TEST_CASE(test_padded)


### PR DESCRIPTION
This fixed a bug where Mist would not be able to create a contract.
