### PR TITLE
Provide simple key management for eth

### DIFF
--- a/libdevcrypto/SecretStore.cpp
+++ b/libdevcrypto/SecretStore.cpp
@@ -266,16 +266,24 @@ bool SecretStore::recode(Address const& _address, string const& _newPass, functi
 	if (s.empty())
 		return false;
 
+	auto k = key(_address);
+	if (k)
+	{
+		k->second.encryptedKey = encrypt(s.ref(), _newPass, _kdf);
+		save();
+		return true;
+	}
+	return false;
+}
+
+std::pair<const h128, SecretStore::EncryptedKey>* SecretStore::key(Address const& _address)
+{
 	for (auto& k: m_keys)
 	{
 		if (k.second.address == _address)
-		{
-			k.second.encryptedKey = encrypt(s.ref(), _newPass, _kdf);
-			save();
-			return true;
-		}
+			return &k;
 	}
-	return false;
+	return nullptr;
 }
 
 bool SecretStore::recode(h128 const& _uuid, string const& _newPass, function<string()> const& _pass, KDF _kdf)

--- a/libdevcrypto/SecretStore.cpp
+++ b/libdevcrypto/SecretStore.cpp
@@ -121,8 +121,7 @@ bytesSec SecretStore::secret(h128 const& _uuid, function<string()> const& _pass,
 bytesSec SecretStore::secret(Address const& _address, function<string()> const& _pass) const
 {
 	bytesSec ret;
-	auto k = key(_address);
-	if (k)
+	if (auto k = key(_address))
 		ret = bytesSec(decrypt(k->second.encryptedKey, _pass()));
 	return ret;
 }
@@ -257,8 +256,7 @@ h128 SecretStore::readKeyContent(string const& _content, string const& _file)
 
 bool SecretStore::recode(Address const& _address, string const& _newPass, function<string()> const& _pass, KDF _kdf)
 {
-	auto k = key(_address);
-	if (k)
+	if (auto k = key(_address))
 	{
 		bytesSec s = secret(_address, _pass);
 		if (s.empty())

--- a/libdevcrypto/SecretStore.cpp
+++ b/libdevcrypto/SecretStore.cpp
@@ -120,16 +120,11 @@ bytesSec SecretStore::secret(h128 const& _uuid, function<string()> const& _pass,
 
 bytesSec SecretStore::secret(Address const& _address, function<string()> const& _pass) const
 {
-	bytesSec key;
-	for (auto const& k: m_keys)
-	{
-		if (k.second.address == _address)
-		{
-			key = bytesSec(decrypt(k.second.encryptedKey, _pass()));
-			break;
-		}
-	}
-	return key;
+	bytesSec ret;
+	auto k = key(_address);
+	if (k)
+		ret = bytesSec(decrypt(k->second.encryptedKey, _pass()));
+	return ret;
 }
 
 bytesSec SecretStore::secret(string const& _content, string const& _pass)
@@ -262,27 +257,35 @@ h128 SecretStore::readKeyContent(string const& _content, string const& _file)
 
 bool SecretStore::recode(Address const& _address, string const& _newPass, function<string()> const& _pass, KDF _kdf)
 {
-	bytesSec s = secret(_address, _pass);
-	if (s.empty())
-		return false;
-
 	auto k = key(_address);
 	if (k)
 	{
-		k->second.encryptedKey = encrypt(s.ref(), _newPass, _kdf);
-		save();
-		return true;
+		bytesSec s = secret(_address, _pass);
+		if (s.empty())
+			return false;
+		else
+		{
+			k->second.encryptedKey = encrypt(s.ref(), _newPass, _kdf);
+			save();
+			return true;
+		}
 	}
 	return false;
 }
 
-std::pair<const h128, SecretStore::EncryptedKey>* SecretStore::key(Address const& _address)
+pair<h128 const, SecretStore::EncryptedKey> const* SecretStore::key(Address const& _address) const
 {
-	for (auto& k: m_keys)
-	{
+	for (auto const& k: m_keys)
 		if (k.second.address == _address)
 			return &k;
-	}
+	return nullptr;
+}
+
+pair<h128 const, SecretStore::EncryptedKey>* SecretStore::key(Address const& _address)
+{
+	for (auto& k: m_keys)
+		if (k.second.address == _address)
+			return &k;
 	return nullptr;
 }
 

--- a/libdevcrypto/SecretStore.cpp
+++ b/libdevcrypto/SecretStore.cpp
@@ -268,16 +268,17 @@ bool SecretStore::recode(Address const& _address, string const& _newPass, functi
 
 	for (auto& k: m_keys)
 	{
-		if (k.address == _address)
+		if (k.second.address == _address)
 		{
-			k.encryptedKey = encrypt(s.ref(), _newPass, _kdf);
+			k.second.encryptedKey = encrypt(s.ref(), _newPass, _kdf);
+			break;
 		}
 	}
 	save();
 	return true;
 }
 
-/*bool SecretStore::recode(h128 const& _uuid, string const& _newPass, function<string()> const& _pass, KDF _kdf)
+bool SecretStore::recode(h128 const& _uuid, string const& _newPass, function<string()> const& _pass, KDF _kdf)
 {
 	bytesSec s = secret(_uuid, _pass, true);
 	if (s.empty())
@@ -286,7 +287,7 @@ bool SecretStore::recode(Address const& _address, string const& _newPass, functi
 	m_keys[_uuid].encryptedKey = encrypt(s.ref(), _newPass, _kdf);
 	save();
 	return true;
-}*/
+}
 
 static bytesSec deriveNewKey(string const& _pass, KDF _kdf, js::mObject& o_ret)
 {

--- a/libdevcrypto/SecretStore.cpp
+++ b/libdevcrypto/SecretStore.cpp
@@ -271,11 +271,11 @@ bool SecretStore::recode(Address const& _address, string const& _newPass, functi
 		if (k.second.address == _address)
 		{
 			k.second.encryptedKey = encrypt(s.ref(), _newPass, _kdf);
-			break;
+			save();
+			return true;
 		}
 	}
-	save();
-	return true;
+	return false;
 }
 
 bool SecretStore::recode(h128 const& _uuid, string const& _newPass, function<string()> const& _pass, KDF _kdf)

--- a/libdevcrypto/SecretStore.h
+++ b/libdevcrypto/SecretStore.h
@@ -127,6 +127,8 @@ private:
 	static std::string encrypt(bytesConstRef _v, std::string const& _pass, KDF _kdf = KDF::Scrypt);
 	/// Decrypts @a _v with a key derived from @a _pass or the empty byte array on error.
 	static bytesSec decrypt(std::string const& _v, std::string const& _pass);
+	/// @returns the key given the @a _address.
+	std::pair<const h128, EncryptedKey>* key(Address const& _address);
 
 	/// Stores decrypted keys by uuid.
 	mutable std::unordered_map<h128, bytesSec> m_cached;

--- a/libdevcrypto/SecretStore.h
+++ b/libdevcrypto/SecretStore.h
@@ -83,8 +83,8 @@ public:
 	h128 importSecret(bytesSec const& _s, std::string const& _pass);
 	h128 importSecret(bytesConstRef _s, std::string const& _pass);
 	/// Decrypts and re-encrypts the key identified by @a _uuid.
-	//bool recode(h128 const& _uuid, std::string const& _newPass, std::function<std::string()> const& _pass, KDF _kdf = KDF::Scrypt);
-	/// /// Decrypts and re-encrypts the key identified by @a _address.
+	bool recode(h128 const& _uuid, std::string const& _newPass, std::function<std::string()> const& _pass, KDF _kdf = KDF::Scrypt);
+	/// Decrypts and re-encrypts the key identified by @a _address.
 	bool recode(Address const& _address, std::string const& _newPass, std::function<std::string()> const& _pass, KDF _kdf = KDF::Scrypt);
 	/// Removes the key specified by @a _uuid from both memory and disk.
 	void kill(h128 const& _uuid);

--- a/libdevcrypto/SecretStore.h
+++ b/libdevcrypto/SecretStore.h
@@ -70,6 +70,9 @@ public:
 	/// @returns the secret key stored by the given @a _uuid.
 	/// @param _pass function that returns the password for the key.
 	static bytesSec secret(std::string const& _content, std::string const& _pass);
+	/// @returns the secret key stored by the given @a _address.
+	/// @param _pass function that returns the password for the key.
+	bytesSec secret(Address const& _address, std::function<std::string()> const& _pass) const;
 	/// Imports the (encrypted) key stored in the file @a _file and copies it to the managed directory.
 	h128 importKey(std::string const& _file) { auto ret = readKey(_file, false); if (ret) save(); return ret; }
 	/// Imports the (encrypted) key contained in the json formatted @a _content and stores it in
@@ -80,7 +83,9 @@ public:
 	h128 importSecret(bytesSec const& _s, std::string const& _pass);
 	h128 importSecret(bytesConstRef _s, std::string const& _pass);
 	/// Decrypts and re-encrypts the key identified by @a _uuid.
-	bool recode(h128 const& _uuid, std::string const& _newPass, std::function<std::string()> const& _pass, KDF _kdf = KDF::Scrypt);
+	//bool recode(h128 const& _uuid, std::string const& _newPass, std::function<std::string()> const& _pass, KDF _kdf = KDF::Scrypt);
+	/// /// Decrypts and re-encrypts the key identified by @a _address.
+	bool recode(Address const& _address, std::string const& _newPass, std::function<std::string()> const& _pass, KDF _kdf = KDF::Scrypt);
 	/// Removes the key specified by @a _uuid from both memory and disk.
 	void kill(h128 const& _uuid);
 

--- a/libdevcrypto/SecretStore.h
+++ b/libdevcrypto/SecretStore.h
@@ -128,8 +128,8 @@ private:
 	/// Decrypts @a _v with a key derived from @a _pass or the empty byte array on error.
 	static bytesSec decrypt(std::string const& _v, std::string const& _pass);
 	/// @returns the key given the @a _address.
-	std::pair<const h128, EncryptedKey>* key(Address const& _address);
-
+	std::pair<h128 const, EncryptedKey> const* key(Address const& _address) const;
+	std::pair<h128 const, EncryptedKey>* key(Address const& _address);
 	/// Stores decrypted keys by uuid.
 	mutable std::unordered_map<h128, bytesSec> m_cached;
 	/// Stores encrypted keys together with the file they were loaded from by uuid.


### PR DESCRIPTION
continuation of 
https://github.com/ethereum/webthree-umbrella/issues/297
- make everything work with addresses and not only UUIDs (recode option)
- by default create a wallet using empty password and don't ask the user for it 
