### PR TITLE
Upstreamed versions of my BuildInfo.h path edits from the cpp-ethereum repo merger branch.

### DIFF
--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -22,7 +22,11 @@
 #include "Common.h"
 #include "Exceptions.h"
 #include "Log.h"
+#if ETH_AFTER_REPOSITORY_MERGE
+#include "cpp-ethereum/BuildInfo.h"
+#else
 #include "dev/BuildInfo.h"
+#endif // ETH_AFTER_REPOSITORY_MERGE
 using namespace std;
 using namespace dev;
 


### PR DESCRIPTION
They are inside pre-processor conditionals, which will be used to bridge the migration gap, and then removed when we are on the other side.
This pattern lets us share identical code between the two directory structures.
