### PR TITLE
Re-adding getThreadName() and setThreadName() to Log.cpp.

### DIFF
--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -175,7 +175,7 @@ extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(const char* l
 
 string dev::getThreadName()
 {
-#if defined(__APPLE__)
+#if defined(__GLIBC__) || defined(__APPLE__)
 	char buffer[128];
 	pthread_getname_np(pthread_self(), buffer, 127);
 	buffer[127] = 0;
@@ -187,7 +187,9 @@ string dev::getThreadName()
 
 void dev::setThreadName(string const& _n)
 {
-#if defined(__APPLE__)
+#if defined(__GLIBC__)
+	pthread_setname_np(pthread_self(), _n.c_str());
+#elif defined(__APPLE__)
 	pthread_setname_np(_n.c_str());
 #else
 	g_logThreadName.m_name.reset(new std::string(_n));

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -98,6 +98,28 @@ public:
 };
 
 /// Set the current thread's log name.
+///
+/// It appears that there is not currently any cross-platform way of setting
+/// thread names either in Boost or in the C++11 runtime libraries.   What is
+/// more, the API for 'pthread_setname_np' is not even consistent across
+/// platforms which implement it.
+///
+/// A proposal to add such functionality on the Boost mailing list, which
+/// I assume never happened, but which I should follow-up and ask about.
+/// http://boost.2283326.n4.nabble.com/Adding-an-option-to-set-the-name-of-a-boost-thread-td4638283.html
+///
+/// man page for 'pthread_setname_np', including this crucial snippet of
+/// information ... "These functions are nonstandard GNU extensions."
+/// http://man7.org/linux/man-pages/man3/pthread_setname_np.3.html
+///
+/// Stack Overflow "Can I set the name of a thread in pthreads / linux?"
+/// which includes useful information on the minor API differences between
+/// Linux, BSD and OS X.
+/// http://stackoverflow.com/questions/2369738/can-i-set-the-name-of-a-thread-in-pthreads-linux/7989973#7989973
+///
+/// musl mailng list posting "pthread set name on MIPs" which includes the
+/// information that musl doesn't currently implement 'pthread_setname_np'
+/// https://marc.info/?l=musl&m=146171729013062&w=1
 void setThreadName(std::string const& _n);
 
 /// Set the current thread's log name.


### PR DESCRIPTION
This is a reworking of https://github.com/ethereum/libweb3core/pull/72, @rainbeam.
I think it would probably be safer to retain the original code for GLIBC platforms (ie. nearly all Linux platforms).

As I'm typing this, I am wondering why we have these direct calls at all, though, rather than using Boost or C++11 threading API?
Anybody know?
