### PR TITLE
Update version number to v1.2.6.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-project(dev VERSION "1.2.5")
+project(dev VERSION "1.2.6")
 
 include(EthCompilerSettings)
 


### PR DESCRIPTION
There are no changes since v.1.2.5, but we're re-publishing the whole umbrella, and everything is still lock stepped.
