### PR TITLE
Update version to 1.2.7.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-project(dev VERSION "1.2.6")
+project(dev VERSION "1.2.7")
 
 include(EthCompilerSettings)
 


### PR DESCRIPTION
Changes since 1.2.6:
- Fixed warnings in clog() macro which were breaking Arch Linux builds.
