### PR TITLE
Fix build on Fedora 22

### DIFF
--- a/libdevcrypto/CMakeLists.txt
+++ b/libdevcrypto/CMakeLists.txt
@@ -2,9 +2,24 @@ aux_source_directory(. SRC_LIST)
 
 set(EXECUTABLE devcrypto)
 
+# Detect Fedora 22
+if(EXISTS "/etc/fedora-release")
+	file (STRINGS "/etc/fedora-release" DISTRO_STRING)
+	set (DISTRO_LIST ${DISTRO_STRING})
+	separate_arguments (DISTRO_LIST)
+	list (GET DISTRO_LIST 2 DISTRO_NUM)
+	if (${DISTRO_NUM} EQUAL 22)
+		set (FEDORA_22 1)
+	endif (${DISTRO_NUM} EQUAL 22)
+endif(EXISTS "/etc/fedora-release")
+
 file(GLOB HEADERS "*.h")
 add_library(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
-add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
+if (NOT DEFINED FEDORA_22)
+	add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
+else (NOT DEFINED FEDORA_22)
+	message (STATUS "Fedora 22 detected - using old ABI")
+endif (NOT DEFINED FEDORA_22)
 eth_use(${EXECUTABLE} REQUIRED Dev::devcore Utils::scrypt Cryptopp)
 
 if (NOT EMSCRIPTEN)


### PR DESCRIPTION
  Fedora 22 uses gcc 5.xx with old ABI set as a default and all libraries
  are compiled with old ABI. Because gcc 5.xx recognizes _GLIBCXX_USE_CXX11_ABI
  we must make sure that it is not defined to avoid ABI incompatibilities.
