### PR TITLE
set/get IpcSocketPath for eth client

### DIFF
--- a/libdevcore/FileSystem.cpp
+++ b/libdevcore/FileSystem.cpp
@@ -39,10 +39,29 @@ using namespace dev;
 
 // Should be written to only once during startup
 static string s_ethereumDatadir;
+static string s_ethereumIpcPath;
 
 void dev::setDataDir(string const& _dataDir)
 {
 	s_ethereumDatadir = _dataDir;
+}
+
+void dev::setIpcPath(string const& _ipcDir)
+{
+	s_ethereumIpcPath = _ipcDir;
+}
+
+string dev::getIpcPath()
+{
+	if (s_ethereumIpcPath.empty())
+		return string(getDataDir());
+	else
+	{
+		size_t socketPos = s_ethereumIpcPath.rfind("geth.ipc");
+		if (socketPos != string::npos)
+			return s_ethereumIpcPath.substr(0, socketPos);
+		return s_ethereumIpcPath;
+	}
 }
 
 string dev::getDataDir(string _prefix)

--- a/libdevcore/FileSystem.h
+++ b/libdevcore/FileSystem.h
@@ -35,5 +35,9 @@ void setDataDir(std::string const& _dir);
 std::string getDataDir(std::string _prefix = "ethereum");
 /// @returns the default path for user data, ignoring the one set by `setDataDir`.
 std::string getDefaultDataDir(std::string _prefix = "ethereum");
+/// Sets the ipc socket dir
+void setIpcPath(std::string const& _ipcPath);
+/// @returns the ipc path (default is DataDir)
+std::string getIpcPath();
 
 }


### PR DESCRIPTION
so you could specify the ipc socket path different from the datadir and connect ethereumWallet to it
depends on 
https://github.com/ethereum/webthree/pull/197
connects to https://github.com/ethereum/webthree-umbrella/issues/678
