### PR TITLE
Re-added devp2p unit-tests which I had disabled post-merger

### DIFF
--- a/test/libp2p/capability.cpp
+++ b/test/libp2p/capability.cpp
@@ -122,14 +122,24 @@ BOOST_AUTO_TEST_CASE(capability)
 	BOOST_REQUIRE(port2);	
 	BOOST_REQUIRE_NE(port1, port2);
 
-	for (int i = 0; i < 3000 && (!host1.isStarted() || !host2.isStarted()); i += step)
+	for (unsigned i = 0; i < 3000; i += step)
+	{
 		this_thread::sleep_for(chrono::milliseconds(step));
+
+		if (host1.isStarted() && host2.isStarted())
+			break;
+	}
 
 	BOOST_REQUIRE(host1.isStarted() && host2.isStarted());
 	host1.requirePeer(host2.id(), NodeIPEndpoint(bi::address::from_string(localhost), port2, port2));
 
-	for (int i = 0; i < 3000 && (!host1.peerCount() || !host2.peerCount()); i += step)
+	for (unsigned i = 0; i < 3000; i += step)
+	{
 		this_thread::sleep_for(chrono::milliseconds(step));
+
+		if ((host1.peerCount() > 0) && (host2.peerCount() > 0))
+			break;
+	}
 
 	BOOST_REQUIRE(host1.peerCount() > 0 && host2.peerCount() > 0);
 


### PR DESCRIPTION
This commit includes some minor code-changes which appear to make the tests reliable again.
The root cause was a thread wait which was terminated when either of two hosts found their peer.
The logic now waits until both hosts find each other.
I suspect that the existing logic was close enough to work most of the time, but the TravisCI environment really exposed the issue almost 100% of the time.
